### PR TITLE
GetHashCode to slow. It now behaves like a normal reference type.

### DIFF
--- a/src/Roseau.DateHelpers/OrderedDates.cs
+++ b/src/Roseau.DateHelpers/OrderedDates.cs
@@ -4,7 +4,7 @@ using Roseau.DateHelpers.DateArrayStrategies;
 
 namespace Roseau.DateHelpers;
 
-public sealed class OrderedDates : IEnumerable<DateOnly>, IEquatable<OrderedDates?>
+public sealed class OrderedDates : IEnumerable<DateOnly>
 {
 	readonly DateOnly[] dates;
 	public OrderedDates(DateOnly[] dates)
@@ -60,28 +60,5 @@ public sealed class OrderedDates : IEnumerable<DateOnly>, IEquatable<OrderedDate
 		DateOnly dateAti = dates[0];
 		while (i <= j && dateAti <= (dateAti = dates[i])) i++;
 		return i > j;
-	}
-	
-	public override int GetHashCode() => ((IStructuralEquatable)dates).GetHashCode(EqualityComparer<DateOnly>.Default);
-	public override bool Equals(object? obj)
-	{
-		if (obj is null)
-			return false;
-		if (obj.GetType() != this.GetType())
-			return false;
-		return Equals(obj as OrderedDates);
-	}
-	public bool Equals(OrderedDates? other)
-	{
-		return other is not null &&
-			   ReferenceEquals(this, other);
-	}
-	public static bool operator ==(OrderedDates? left, OrderedDates? right)
-	{
-		return EqualityComparer<OrderedDates>.Default.Equals(left, right);
-	}
-	public static bool operator !=(OrderedDates? left, OrderedDates? right)
-	{
-		return !(left == right);
 	}
 }

--- a/src/Roseau.DateHelpers/Roseau.DateHelpers.csproj
+++ b/src/Roseau.DateHelpers/Roseau.DateHelpers.csproj
@@ -8,7 +8,7 @@
     <Description>Helper methods to work with DateOnly type.</Description>
     <PackageProjectUrl>https://github.com/Jflaurendeau/Roseau.DateHelpers</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Jflaurendeau/Roseau.DateHelpers.git</RepositoryUrl>
-	<VersionPrefix>0.1.3</VersionPrefix>
+	<VersionPrefix>0.1.4</VersionPrefix>
 	<AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/tests/Roseau.DateHelpers.UnitTests/OrderedDatesUnitTests.cs
+++ b/tests/Roseau.DateHelpers.UnitTests/OrderedDatesUnitTests.cs
@@ -67,7 +67,7 @@ public class OrderedDatesUnitTests
 
 
 	[TestMethod]
-	[TestCategory("Count")]
+	[TestCategory(nameof(OrderedDates.Count))]
 	public void Count_ReturnLengthOfArray_IsTrue()
 	{
 		// Arrange
@@ -83,7 +83,7 @@ public class OrderedDatesUnitTests
 		Assert.AreEqual(expectedDates.Length, dates.Count);
 	}
 	[TestMethod]
-	[TestCategory("AsSpan")]
+	[TestCategory(nameof(OrderedDates.AsSpan))]
 	public void AsSpan_ReturnSpanOverArray_IsTrue()
 	{
 		// Arrange
@@ -92,7 +92,6 @@ public class OrderedDatesUnitTests
 		var strategy = new FirstDayOfEveryMonthStrategy();
 
 		// Act
-		var expectedDates = strategy.GetDates(calculationDate, lastDate);
 		var dates = new OrderedDates(strategy, calculationDate, lastDate);
 		var datesSpan = dates.AsSpan();
 		var count = dates.Count;
@@ -104,7 +103,7 @@ public class OrderedDatesUnitTests
 		}
 	}
 	[TestMethod]
-	[TestCategory("AsSpan")]
+	[TestCategory(nameof(OrderedDates.AsSpan))]
 	public void AsSpan_ReturnSpanOverWithStart_IsTrue()
 	{
 		// Arrange
@@ -125,7 +124,7 @@ public class OrderedDatesUnitTests
 		}
 	}
 	[TestMethod]
-	[TestCategory("AsSpan")]
+	[TestCategory(nameof(OrderedDates.AsSpan))]
 	public void AsSpan_ReturnSpanOverArrayWithStartAndLenght_IsTrue()
 	{
 		// Arrange
@@ -147,7 +146,7 @@ public class OrderedDatesUnitTests
 		}
 	}
 	[TestMethod]
-	[TestCategory("AsMemory")]
+	[TestCategory(nameof(OrderedDates.AsMemory))]
 	public void AsMemory_ReturnMemoryOverArray_IsTrue()
 	{
 		// Arrange
@@ -156,7 +155,6 @@ public class OrderedDatesUnitTests
 		var strategy = new FirstDayOfEveryMonthStrategy();
 
 		// Act
-		var expectedDates = strategy.GetDates(calculationDate, lastDate);
 		var dates = new OrderedDates(strategy, calculationDate, lastDate);
 		var datesMemory = dates.AsMemory();
 		var datesSpan = datesMemory.Span;
@@ -169,7 +167,7 @@ public class OrderedDatesUnitTests
 		}
 	}
 	[TestMethod]
-	[TestCategory("AsMemory")]
+	[TestCategory(nameof(OrderedDates.AsMemory))]
 	public void AsMemory_ReturnMemoryOverArrayWithStart_IsTrue()
 	{
 		// Arrange
@@ -192,7 +190,7 @@ public class OrderedDatesUnitTests
 		}
 	}
 	[TestMethod]
-	[TestCategory("AsMemory")]
+	[TestCategory(nameof(OrderedDates.AsMemory))]
 	public void AsMemory_ReturnMemoryOverArrayWithStartAndLength_IsTrue()
 	{
 		// Arrange
@@ -215,7 +213,7 @@ public class OrderedDatesUnitTests
 		}
 	}
 	[TestMethod]
-	[TestCategory("Contains")]
+	[TestCategory(nameof(OrderedDates.Contains))]
 	public void Contains_FeededByARealValue_IsTrue()
 	{
 		// Arrange
@@ -228,7 +226,7 @@ public class OrderedDatesUnitTests
 		Assert.IsTrue(dates.Contains(new(2022,3,1)));
 	}
 	[TestMethod]
-	[TestCategory("Contains")]
+	[TestCategory(nameof(OrderedDates.Contains))]
 	public void Contains_DoesNotContainsAValue_IsFalse()
 	{
 		// Arrange
@@ -241,7 +239,7 @@ public class OrderedDatesUnitTests
 		Assert.IsFalse(dates.Contains(new(2022, 3, 2)));
 	}
 	[TestMethod]
-	[TestCategory("IndexOfOrPreviousElement")]
+	[TestCategory(nameof(OrderedDates.IndexOfOrPreviousElement))]
 	public void IndexOfOrPreviousElement_ElementIsInArray_ReturnGoodIndex()
 	{
 		// Arrange
@@ -255,7 +253,7 @@ public class OrderedDatesUnitTests
 		Assert.AreEqual(expectedDates[0], date);
 	}
 	[TestMethod]
-	[TestCategory("IndexOfOrPreviousElement")]
+	[TestCategory(nameof(OrderedDates.IndexOfOrPreviousElement))]
 	public void IndexOfOrPreviousElement_ElementIsBeforeFirstElementOfArray_ReturnGoodIndex()
 	{
 		// Arrange
@@ -272,7 +270,7 @@ public class OrderedDatesUnitTests
 		Assert.AreEqual(expectedIndex, index);
 	}
 	[TestMethod]
-	[TestCategory("IndexOfOrPreviousElement")]
+	[TestCategory(nameof(OrderedDates.IndexOfOrPreviousElement))]
 	public void IndexOfOrPreviousElement_ElementIsAfterFirstElementOfArray_ReturnGoodIndex()
 	{
 		// Arrange
@@ -289,7 +287,7 @@ public class OrderedDatesUnitTests
 		Assert.AreEqual(expectedDate, date);
 	}
 	[TestMethod]
-	[TestCategory("IndexOfOrPreviousElement")]
+	[TestCategory(nameof(OrderedDates.IndexOfOrPreviousElement))]
 	public void IndexOfOrPreviousElement_ElementIsAfterLasElementOfArray_ReturnGoodIndex()
 	{
 		// Arrange
@@ -306,7 +304,7 @@ public class OrderedDatesUnitTests
 		Assert.AreEqual(expectedDate, date);
 	}
 	[TestMethod]
-	[TestCategory("IsSorted")]
+	[TestCategory(nameof(OrderedDates.IsSorted))]
 	public void IsSorted_GivenASortedArry_ReturnsTrue()
 	{
 		// Arrange
@@ -317,7 +315,7 @@ public class OrderedDatesUnitTests
 		Assert.IsTrue(OrderedDates.IsSorted(dates));
 	}
 	[TestMethod]
-	[TestCategory("IsSorted")]
+	[TestCategory(nameof(OrderedDates.IsSorted))]
 	public void IsSorted_GivenAnUnsortedArry_ReturnsFalse()
 	{
 		// Arrange
@@ -330,7 +328,7 @@ public class OrderedDatesUnitTests
 		Assert.IsFalse(OrderedDates.IsSorted(temporaryDate));
 	}
 	[TestMethod]
-	[TestCategory("IsSorted")]
+	[TestCategory(nameof(OrderedDates.IsSorted))]
 	public void IsSorted_ArrayOfLessThanTwoElements_ReturnsTrue()
 	{
 		// Arrange
@@ -344,7 +342,7 @@ public class OrderedDatesUnitTests
 		Assert.IsTrue(OrderedDates.IsSorted(dates1));
 	}
 	[TestMethod]
-	[TestCategory("IsSorted")]
+	[TestCategory(nameof(OrderedDates.IsSorted))]
 	public void IsSorted_ArgumentNull_ThrowArgumentNullException()
 	{
 		// Arrange
@@ -354,7 +352,7 @@ public class OrderedDatesUnitTests
 		Assert.ThrowsException<ArgumentNullException>(() => OrderedDates.IsSorted(null!));
 	}
 	[TestMethod]
-	[TestCategory("IsSorted")]
+	[TestCategory(nameof(OrderedDates.IsSorted))]
 	public void Indexer_IndexOfIndexerSameAsArray_ReturnsTrue()
 	{
 		// Arrange
@@ -369,7 +367,7 @@ public class OrderedDatesUnitTests
 		}
 	}
 	[TestMethod]
-	[TestCategory("AsCollection")]
+	[TestCategory(nameof(OrderedDates.AsCollection))]
 	public void AsCollection_ReturnCollectionOfArray_IsTrue()
 	{
 		// Arrange
@@ -426,180 +424,6 @@ public class OrderedDatesUnitTests
 			}
 		}
 		Assert.AreEqual(dates.Length, i);
-	}
-	[TestMethod]
-	[TestCategory("GetHashCode")]
-	public void GetHashCode_SameArrayWithTwoOrderedDate_ReturnSameHashCode()
-	{
-		// Arrange
-		var calculationDate = new DateOnly(2022, 2, 15);
-		var lastDate = new DateOnly(2023, 2, 28);
-		var strategy = new FirstDayOfEveryMonthStrategy();
-
-		// Act
-		var expectedDates = strategy.GetDates(calculationDate, lastDate);
-		var expectedOrderedDates = new OrderedDates(expectedDates);
-		var dates = new OrderedDates(strategy, calculationDate, lastDate);
-
-		// Assert
-		Assert.AreEqual(expectedOrderedDates.GetHashCode(), dates.GetHashCode());
-		
-	}
-	[TestMethod]
-	[TestCategory("GetHashCode")]
-	public void GetHashCode_DifferentArrayWithTwoOrderedDate_ReturnDifferentHashCode()
-	{
-		// Arrange
-		var calculationDate = new DateOnly(2022, 2, 15);
-		var lastDate = new DateOnly(2023, 2, 28);
-		var strategy = new FirstDayOfEveryMonthStrategy();
-
-		// Act
-		var expectedDates = strategy.GetDates(calculationDate, lastDate);
-		expectedDates[^1] = lastDate;
-		var expectedOrderedDates = new OrderedDates(expectedDates);
-		var dates = new OrderedDates(strategy, calculationDate, lastDate);
-
-		// Assert
-		Assert.AreNotEqual(expectedOrderedDates.GetHashCode(), dates.GetHashCode());
-	}
-	[TestMethod]
-	[TestCategory("Equals")]
-	public void Equals_DifferentTypes_IsFalse()
-	{
-		// Arrange
-		var calculationDate = new DateOnly(2022, 2, 15);
-		var lastDate = new DateOnly(2023, 2, 28);
-		var strategy = new FirstDayOfEveryMonthStrategy();
-
-		// Act
-		var expectedDates = strategy.GetDates(calculationDate, lastDate);
-		var expectedOrderedDates = new OrderedDates(expectedDates);
-		var dates = new OrderedDates(strategy, calculationDate, lastDate);
-
-		// Assert
-		Assert.IsFalse(expectedOrderedDates.Equals(calculationDate));
-	}
-	[TestMethod]
-	[TestCategory("Equals")]
-	public void Equals_ComparisonAgainstNullDifferentObject_IsFalse()
-	{
-		// Arrange
-		var calculationDate = new DateOnly(2022, 2, 15);
-		var lastDate = new DateOnly(2023, 2, 28);
-		var strategy = new FirstDayOfEveryMonthStrategy();
-		FirstDayOfEveryMonthStrategy nullStrategy = default!;
-
-		// Act
-		var expectedDates = strategy.GetDates(calculationDate, lastDate);
-		var expectedOrderedDates = new OrderedDates(expectedDates);
-		var dates = new OrderedDates(strategy, calculationDate, lastDate);
-
-		// Assert
-		Assert.IsFalse(expectedOrderedDates.Equals(nullStrategy));
-	}
-	[TestMethod]
-	[TestCategory("Equals")]
-	public void Equals_ComparisonAgainstNullOrderedDates_IsFalse()
-	{
-		// Arrange
-		var calculationDate = new DateOnly(2022, 2, 15);
-		var lastDate = new DateOnly(2023, 2, 28);
-		var strategy = new FirstDayOfEveryMonthStrategy();
-		OrderedDates nullOrderedDates = default!;
-
-		// Act
-		var expectedDates = strategy.GetDates(calculationDate, lastDate);
-		var expectedOrderedDates = new OrderedDates(expectedDates);
-		var dates = new OrderedDates(strategy, calculationDate, lastDate);
-
-		// Assert
-		Assert.IsFalse(expectedOrderedDates.Equals(nullOrderedDates));
-	}
-	[TestMethod]
-	[TestCategory("Equals")]
-	public void Equals_ComparisonAgainstDifferentOrderedDates_IsFalse()
-	{
-		// Arrange
-		var calculationDate = new DateOnly(2022, 2, 15);
-		var lastDate = new DateOnly(2023, 2, 28);
-		var strategy = new FirstDayOfEveryMonthStrategy();
-
-		// Act
-		var expectedDates = strategy.GetDates(calculationDate, lastDate);
-		var expectedOrderedDates = new OrderedDates(expectedDates);
-		var dates = new OrderedDates(strategy, calculationDate, lastDate);
-
-		// Assert
-		Assert.IsFalse(expectedOrderedDates.Equals(dates));
-	}
-	[TestMethod]
-	[TestCategory("Equals")]
-	public void Equals_ComparisonAgainstSameOrderedDates_IsTrue()
-	{
-		// Arrange
-		var calculationDate = new DateOnly(2022, 2, 15);
-		var lastDate = new DateOnly(2023, 2, 28);
-		var strategy = new FirstDayOfEveryMonthStrategy();
-
-		// Act
-		var expectedDates = strategy.GetDates(calculationDate, lastDate);
-		var expectedOrderedDates = new OrderedDates(expectedDates);
-		var dates = expectedOrderedDates;
-
-		// Assert
-		Assert.IsTrue(expectedOrderedDates.Equals(dates));
-	}
-	[TestMethod]
-	[TestCategory("Equals")]
-	public void Equals_ComparisonAgainstSameOrderedDatesBoxedAsObject_IsTrue()
-	{
-		// Arrange
-		var calculationDate = new DateOnly(2022, 2, 15);
-		var lastDate = new DateOnly(2023, 2, 28);
-		var strategy = new FirstDayOfEveryMonthStrategy();
-
-		// Act
-		var expectedDates = strategy.GetDates(calculationDate, lastDate);
-		var expectedOrderedDates = new OrderedDates(expectedDates);
-		var dates = expectedOrderedDates;
-
-		// Assert
-		Assert.IsTrue(expectedOrderedDates.Equals((object)dates));
-	}
-	[TestMethod]
-	[TestCategory("Equals")]
-	public void EqualOperator_ComparisonAgainstSameOrderedDates_IsTrue()
-	{
-		// Arrange
-		var calculationDate = new DateOnly(2022, 2, 15);
-		var lastDate = new DateOnly(2023, 2, 28);
-		var strategy = new FirstDayOfEveryMonthStrategy();
-
-		// Act
-		var expectedDates = strategy.GetDates(calculationDate, lastDate);
-		var expectedOrderedDates = new OrderedDates(expectedDates);
-		var dates = expectedOrderedDates;
-
-		// Assert
-		Assert.IsTrue(expectedOrderedDates == dates);
-	}
-	[TestMethod]
-	[TestCategory("Equals")]
-	public void NotEqualOperator_ComparisonAgainstDifferentOrderedDates_IsTrue()
-	{
-		// Arrange
-		var calculationDate = new DateOnly(2022, 2, 15);
-		var lastDate = new DateOnly(2023, 2, 28);
-		var strategy = new FirstDayOfEveryMonthStrategy();
-
-		// Act
-		var expectedDates = strategy.GetDates(calculationDate, lastDate);
-		var expectedOrderedDates = new OrderedDates(expectedDates);
-		var dates = new OrderedDates(expectedDates);
-
-		// Assert
-		Assert.IsTrue(expectedOrderedDates != dates);
 	}
 
 }


### PR DESCRIPTION
Changing the equality and gethashcode method so that they behave as a developer would suspect a reference type would.